### PR TITLE
Disable WordPress core's enhanced lazy-loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [0.2.3] - 2022-02-21
+
+### Added
+* Disables WordPress core's enhanced lazy-loading [[#4](https://github.com/wearetinybit/tinybit-core-plugin/pull/4)].
+
+## [0.2.2] - 2022-02-18
+
+### Fixed
+* Fixes issue where content would end up repeating [[#3](https://github.com/wearetinybit/tinybit-core-plugin/pull/3)].
+
+## [0.2.1] - 2022-02-18
+
+### Added
+* Eager loads images within the first four paragraphs of content [[#2](https://github.com/wearetinybit/tinybit-core-plugin/pull/2)].

--- a/tinybit-core.php
+++ b/tinybit-core.php
@@ -7,7 +7,7 @@
  * Author URI:      YOUR SITE HERE
  * Text Domain:     tinybit-core
  * Domain Path:     /languages
- * Version:         0.2.2
+ * Version:         0.2.3
  *
  * @package         TBC
  */

--- a/tinybit-core.php
+++ b/tinybit-core.php
@@ -34,6 +34,8 @@ tbc_register_class_hooks(
 	]
 );
 
+add_filter( 'wp_omit_loading_attr_threshold', '__return_zero' );
+
 /*
  * TBC\Integrations\Cloudflare
  */


### PR DESCRIPTION
We've implemented our own.